### PR TITLE
add gh-pages script and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,13 +555,15 @@ pages that are hosted by GitHub and can easily be published via
 GitHub.  You can post the website for your Maven projects by first
 creating a `gh-pages` branch (from the initial revision of the 
 repository), removing the `README.md` file on that branch (because
-it will take precedence over the generated `index.html` file) and
-pushing it to GitHub:
+it will take precedence over the generated `index.html` file), 
+removing `*.zip` from `.gitignore` (because the Maven process will add
+.zip files to the `gh-pages` branch) and pushing it to GitHub:
 
 ```
 $ git checkout 62fc42c5b0cf4ddddf78e7568b008bedc9037b38
 $ git branch gh-pages
 $ git rm README.md
+$ git add .gitignore
 $ git commit -m "Remove README.md on gh-pages branch" README.md
 $ git push --set-upstream origin gh-pages
 $ git checkout main

--- a/gh-pages-deploy.sh
+++ b/gh-pages-deploy.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+setup_gh_branch() {
+    if git show-ref -q --heads "gh-pages"; then     # check if gh-pages branch exists
+        git checkout gh-pages                       # checkout existing branch
+    else 
+        echo "** Creating new branch: gh-pages **"
+        git checkout -b gh-pages                    # create gh-pages and checkout
+    fi
+
+    update_files                                    # update files in gh-pages branch
+    git checkout main                               # checkout main branch
+    
+}
+
+update_files() {
+    has_change=0                                    # files were modified bool
+    if [ -f README.md ]; then                       # check if root level readme exists
+        echo "** Removing README.md **"
+        rm README.md;                               # delete root level readme
+        git add README.md                           # stage delete in git
+        has_change=1
+    fi
+
+    if [ ! -z $(grep "*.zip" .gitignore) ]; then    # check if *.zip is present in .gitignore
+        echo "** Removing *.zip from .gitignore"
+        sed -i /"*.zip"/d .gitignore;               # remove the *.zip line from .gitignore
+        git add .gitignore                          # stage .gitignore modifications in git
+        has_change=1
+    fi
+
+    if [ $has_change -eq 1 ]; then                  # if files were modified, commit changes
+        echo "** Committing updates to git **"
+        git commit -m "REMOVE README.md and update .gitignore on gh-pages branch"
+    fi
+}
+
+deploy_gh_pages() {
+    setup_gh_branch                                 # prep gh-pages branch for site deployment
+    ./mvnw site                                     # create site files
+    ./mvnw site:stage                               # gather site files across projects
+    ./mvnw scm-publish:publish-scm                  # upload site files to gh-pages branch
+}
+
+deploy_gh_pages


### PR DESCRIPTION
- Adds gh-pages script that:
  - creates `gh-pages` branch if it doesn't exist
  - checkouts existing or new branch
  - deletes root level README.md
  - updates .gitignore to remove `*.zip` (mvnw scm:publish pushes .zip files)
  - commits changes to `gh-pages` branch
  - checkouts `main` and runs:
    - `mvnw site`
    - `mvnw site:stage`
    - `mvnw scm-publish:publish-scm`
 - Update README.md to reflect `*.zip` changes in .gitignore