### PR TITLE
Changes for Winter 2024

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '17', '20' ]
+        java: [ '17', '21' ]
     name: JDK ${{ matrix.Java }}
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -483,9 +483,9 @@ is my top-level POM) to something like:
 
 ```xml
   <parent>
-    <artifactId>PortlandStateJavaSummer2023</artifactId>
+    <artifactId>PortlandStateJava</artifactId>
     <groupId>edu.pdx.cs410J.your-mcecs-user-id</groupId>
-    <version>2023.0.0</version>
+    <version>1.0.0</version>
   </parent>
 ```
 
@@ -515,7 +515,7 @@ In order to debug code running as an executable jar, you must specify the `-agen
 to the `-jar` option:
 
 ```
-java -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005 -jar target/student-2023.0.0.jar 
+java -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005 -jar target/student-1.0.0.jar 
 ```
 
 The above `-agentlib` option causes the JVM to output a (rather cryptic) informational message indicating that the JVM
@@ -563,9 +563,9 @@ your group:
 
 ```xml
   <parent>
-    <artifactId>PortlandStateJavaSummer2023</artifactId>
+    <artifactId>PortlandStateJava</artifactId>
     <groupId>edu.pdx.cs410J.your-mcecs-user-id</groupId>
-    <version>2023.0.0</version>
+    <version>1.0.0</version>
   </parent>
 ```
 

--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ After your code has been successfully submitted, the `submit.sh` script will
 [tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) the current revision of 
 your git repository. The name of the tag indicates which project was submitted and
 the date/time it was submitted.  For example, submitting Project1 at 9 AM on May 1st
-would tag the current revision of the repository with `submit-Project1-20230501T09:00:58`.
+would tag the current revision of the repository with `submit-Project1-20240501T09:00:58`.
 This tag allows you to create a [branch](https://git-scm.com/book/en/v2/Git-Branching-Basic-Branching-and-Merging)
 from the specific revision of your code that was submitted, which makes debugging problems
 in submitted code much easier.  Note that the `submit.sh` will issue an error if there are
@@ -405,7 +405,7 @@ $ git push --tags
 
 To push individual tag:
 ```shell
-$ git push origin submit-Project1-20230501T09:00:58
+$ git push origin submit-Project1-20240501T09:00:58
 ```
 
 ### About how long do the projects take to complete?
@@ -474,7 +474,7 @@ When created, the `pom.xml` files for the projects specify a parent of _my_ top-
   <parent>
     <artifactId>cs410j</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2023.1.0</version>
+    <version>2024.0.0</version>
   </parent>
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Java CI with Maven](https://github.com/YourGitHubId/PortlandStateJavaSummer2023/actions/workflows/maven.yml/badge.svg)](https://github.com/YourGitHubId/PortlandStateJavaSummer2023/actions/workflows/maven.yml)
+[![Java CI with Maven](https://github.com/YourGitHubId/PortlandStateJavaWinter2024/actions/workflows/maven.yml/badge.svg)](https://github.com/YourGitHubId/PortlandStateJavaWinter2024/actions/workflows/maven.yml)
 
 # Getting Started with Advanced Programming with Java
 
@@ -72,7 +72,7 @@ developer"](https://education.github.com/pack) account that gives you
 free private repositories.  Then [create a private GitHub
 repository from this "template" repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template)
 for your source code for this course.  (In this example, the
-repository is named "PortlandStateJavaSummer2023".)
+repository is named "PortlandStateJavaWinter2024".)
 
 Again, please ensure that all of your code for the assignments is in a 
 **private** GitHub repository.  GitHub makes it very easy for people to
@@ -100,7 +100,7 @@ The following command lines assume that you are running in the
 directory created by cloning the repository.
 
 ```sh
-$ cd PortlandStateJavaSummer2023
+$ cd PortlandStateJavaWinter2024
 ```
 
 ### How do I use the Java Development Kit?
@@ -238,7 +238,7 @@ clone by adding the directory to git.
 
 ```sh
 $ ./mvnw clean     # Remove files that shouldn't be committed to version control
-$ cd ..            # to PortlandStateJavaSummer2023 directory
+$ cd ..            # to PortlandStateJavaWinter2024 directory
 $ git add student
 $ git commit -m "Added source files for student project"
 ```
@@ -297,7 +297,7 @@ After `ssh`ing to one of the CS Department's Linux machines, you can
 make a clone of your GitHub repository using with:
 
 ```
-$ git clone https://github.com/YourGitHubId/PortlandStateJavaSummer2023.git
+$ git clone https://github.com/YourGitHubId/PortlandStateJavaWinter2024.git
 ```
 
 ### How can I get changes that other people make into my clone?
@@ -311,7 +311,7 @@ First, configure your repository to have this repository to be a
 "remote" named "upstream".
 
 ```sh
-$ cd PortlandStateJavaSummer2023
+$ cd PortlandStateJavaWinter2024
 $ git remote add upstream https://github.com/DavidWhitlock/PortlandStateJavaGettingStarted.git
 ```
 
@@ -454,8 +454,8 @@ As you create Maven projects in this repository, you may encounter warnings like
 
 ```
 [WARNING] 
-[WARNING] Some problems were encountered while building the effective model for edu.pdx.cs410J.whitlock:apptbook:jar:2023.0.0
-[WARNING] 'parent.relativePath' of POM edu.pdx.cs410J.whitlock:apptbook:2023.0.0 (PortlandStateJavaSummer2023/apptbook/pom.xml) points at edu.pdx.cs410J.whitlock:PortlandStateJavaSummer2023 instead of io.github.davidwhitlock.cs410J:cs410j, please verify your project structure @ line 3, column 11
+[WARNING] Some problems were encountered while building the effective model for edu.pdx.cs410J.whitlock:apptbook:jar:1.0.0
+[WARNING] 'parent.relativePath' of POM edu.pdx.cs410J.whitlock:apptbook:1.0.0 (PortlandStateJavaWinter2024/apptbook/pom.xml) points at edu.pdx.cs410J.whitlock:PortlandStateJavaWinter2024 instead of io.github.davidwhitlock.cs410J:cs410j, please verify your project structure @ line 3, column 11
 [WARNING] 
 [WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
 [WARNING] 
@@ -558,7 +558,7 @@ Running `mvn site` from the root directory of this repository will
 generate a website that provides lots of information (reports, etc.) 
 about the Maven projects.  Note that in order for your multi-project
 Maven site to generate correctly, the subprojects must specify that
-their parent project is the `PortlandStateJavaSummer2023` project in
+their parent project is the `PortlandStateJavaWinter2024` project in
 your group:
 
 ```xml
@@ -601,7 +601,7 @@ You can open `target/staging/index.html` in your web browse to see
 what your site will look like.
 
 Verify that your website is available at a URL like:
-https://yourgithubuser.github.io/PortlandStateJavaSummer2023
+https://yourgithubuser.github.io/PortlandStateJavaWinter2024
 
 ## How can I improve this repository?
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 [![Java CI with Maven](https://github.com/YourGitHubId/PortlandStateJavaWinter2024/actions/workflows/maven.yml/badge.svg)](https://github.com/YourGitHubId/PortlandStateJavaWinter2024/actions/workflows/maven.yml)
 
-# Getting Started with Advanced Programming with Java
+# Getting Started with Contemporary Software Development
 
-This repository helps students in [Advanced Programming with
-Java](http://web.cecs.pdx.edu/~whitlock/) get started with the
-programming assignments.  Most notably, it makes it so students do
-not need to install [Apache Maven](https://maven.apache.org/install.html)
+This repository helps students in [Contemporary Sotfware Development](http://web.cecs.pdx.edu/~whitlock/) get started with the
+programming assignments.  Most notably, it gives students experience working with Git repositories and removed
+the need to install [Apache Maven](https://maven.apache.org/install.html)
 on their local machines (or the PSU machines) in order to create and
 build the programming projects.  It makes liberal use of the [Maven
 Wrapper](https://github.com/takari/maven-wrapper) script which
@@ -76,8 +75,8 @@ repository is named "PortlandStateJavaWinter2024".)
 
 Again, please ensure that all of your code for the assignments is in a 
 **private** GitHub repository.  GitHub makes it very easy for people to
-find your code, and you do **not** want to have your work plagiarized.  
-After the course is over, if you want to make your repository public to
+find your code, and you do **not** want to have your work plagiarized.  After
+the course is over, if you want to make your repository public to
 help contribute to your coding portfolio, that's fine.  I do ask that 
 current students not leverage former students' code to inform their 
 projects.  If you have questions about your code that you'd like me to
@@ -606,8 +605,7 @@ https://yourgithubuser.github.io/PortlandStateJavaWinter2024
 ## How can I improve this repository?
 
 This repository is kind of thrown together, and it ought to evolve to
-meet the needs of the students who take Advanced Programming with
-Java.  
+meet the needs of the students who take Contemporary Software Development.  
 
 Feel free to [create issues](../../issues) for this repository if you find
 something missing or confusing.

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ accordingly
   <parent>
     <artifactId>cs410j</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2023.1.0</version>
+    <version>2024.0.0</version>
   </parent>
   <groupId>edu.pdx.cs410J.YourUserId</groupId>
   <artifactId>PortlandStateJava</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@ accordingly
     <version>2023.1.0</version>
   </parent>
   <groupId>edu.pdx.cs410J.YourUserId</groupId>
-  <artifactId>PortlandStateJavaSummer2023</artifactId>
-  <version>2023.0.0</version>
+  <artifactId>PortlandStateJava</artifactId>
+  <version>1.0.0</version>
 
   <packaging>pom</packaging>
   <name>PSUJavaSummer2023</name>

--- a/pom.xml
+++ b/pom.xml
@@ -19,21 +19,21 @@ accordingly
   <version>1.0.0</version>
 
   <packaging>pom</packaging>
-  <name>PSUJavaSummer2023</name>
-  <description>Source code written in the Summer 2023 offering of Advanced Programming with Java</description>
-  <url>http://YourGitHubUserInLowerCase.github.io/PortlandStateJavaSummer2023</url>
+  <name>PSUJavaWinter2024</name>
+  <description>Source code written in the Winter 2024 offering of Contemporary Software Development</description>
+  <url>http://YourGitHubUserInLowerCase.github.io/PortlandStateJavaWinter2024</url>
 
   <modules>
   </modules>
 
-  <inceptionYear>2023</inceptionYear>
+  <inceptionYear>2024</inceptionYear>
   <organization>
     <name>Portland State University</name>
     <url>http://www.pdx.edu</url>
   </organization>
   <issueManagement>
     <system>github</system>
-    <url>https://github.com/YourGitHubUser/PortlandStateJavaSummer2023/issues</url>
+    <url>https://github.com/YourGitHubUser/PortlandStateJavaWinter2024/issues</url>
   </issueManagement>
   <licenses>
     <license>
@@ -76,7 +76,7 @@ accordingly
       <plugin>
         <artifactId>maven-site-plugin</artifactId>
         <configuration>
-          <topSiteURL>scm:git:git@github.com:YourGithubUser/PortlandStateJavaSummer2023.git</topSiteURL>
+          <topSiteURL>scm:git:git@github.com:YourGithubUser/PortlandStateJavaWinter2024.git</topSiteURL>
         </configuration>
       </plugin>
       <plugin>
@@ -92,7 +92,7 @@ accordingly
   </build>
 
   <scm>
-    <connection>scm:git:git@github.com:YourGithubUser/PortlandStateJavaSummer2023.git</connection>
+    <connection>scm:git:git@github.com:YourGithubUser/PortlandStateJavaWinter2024.git</connection>
   </scm>
   <distributionManagement>
     <snapshotRepository>
@@ -102,7 +102,7 @@ accordingly
     <site>
       <id>gh-pages</id>
       <name>GitHub Pages</name>
-      <url>scm:git:git@github.com:YourGithubUser/PortlandStateJavaSummer2023.git</url>
+      <url>scm:git:git@github.com:YourGithubUser/PortlandStateJavaWinter2024.git</url>
     </site>
   </distributionManagement>
 

--- a/prerequisites.sh
+++ b/prerequisites.sh
@@ -89,7 +89,7 @@ function createProjectFromArchetype() {
 	   -DinteractiveMode=false \
 	   -DarchetypeGroupId=io.github.davidwhitlock.cs410J \
 	   -DarchetypeArtifactId=${archetypeName}-archetype \
-	   -DarchetypeVersion=2023.1.0 \
+	   -DarchetypeVersion=2024.0.0 \
 	   -DgroupId=edu.pdx.cs410J.${loginId} \
 	   -DartifactId=${projectName} \
 	   -Dpackage=edu.pdx.cs410J.${loginId} \

--- a/prerequisites.sh
+++ b/prerequisites.sh
@@ -93,7 +93,7 @@ function createProjectFromArchetype() {
 	   -DgroupId=edu.pdx.cs410J.${loginId} \
 	   -DartifactId=${projectName} \
 	   -Dpackage=edu.pdx.cs410J.${loginId} \
-	   -Dversion=2023.0.0
+	   -Dversion=1.0.0
 
     chmod +x ${projectName}/mvnw
 }

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -17,7 +17,7 @@
       </googleSearch>
       <sourceLineNumbersEnabled>true</sourceLineNumbersEnabled>
       <gitHub>
-        <projectId>YourGitHubUser/PortlandStateJavaSummer2023</projectId>
+        <projectId>YourGitHubUser/PortlandStateJavaWinter2024</projectId>
         <ribbonOrientation>right</ribbonOrientation>
         <ribbonColor>black</ribbonColor>
       </gitHub>

--- a/submit.sh
+++ b/submit.sh
@@ -29,10 +29,10 @@ elif [[ "$project" == "koans"  ]]; then
   directory="koans"
   mavenGoals="clean exec:java"
 
-elif [[ "$project" == "Project4"  ]]; then
+elif [[ "$project" == "Project5"  ]]; then
   directory="apptbook-web"
 
-elif [[ "$project" == "Project5"  ]]; then
+elif [[ "$project" == "Project6"  ]]; then
   directory="apptbook-android"
   submitClass="SubmitAndroidProject"
   srcDirectory="app"


### PR DESCRIPTION
Changes for the Winter 2024 offering of the course include:

- Use version 1.0.0 for the projects created by the archetypes.  It's a more normal version number and we won't need to update it every year.
- Replace "Summer 2023" with "Winter 2024"
- Use Java 21 for continuous integration